### PR TITLE
Add Support for Multiple Locations on WeatherViewController

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,8 @@
+Simple Weather Release Notes
+===========================
+
+Ongoing development ()
+------------------------
+
+### Additions
+- Adds support for multiple locations on `WeatherViewController` \(schipman)

--- a/sample-app.xcodeproj/project.pbxproj
+++ b/sample-app.xcodeproj/project.pbxproj
@@ -18,6 +18,7 @@
 		CAC54C7227E38A6900CB3980 /* sample_appUITestsLaunchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAC54C7127E38A6900CB3980 /* sample_appUITestsLaunchTests.swift */; };
 		CAC54C8527E38CE000CB3980 /* WeatherService.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAC54C8427E38CE000CB3980 /* WeatherService.swift */; };
 		CAC54C8827E393A600CB3980 /* WeatherView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAC54C8727E393A600CB3980 /* WeatherView.swift */; };
+		CAC54C8A27E3AE3200CB3980 /* FollowedLocationsService.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAC54C8927E3AE3200CB3980 /* FollowedLocationsService.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -53,6 +54,7 @@
 		CAC54C7127E38A6900CB3980 /* sample_appUITestsLaunchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = sample_appUITestsLaunchTests.swift; sourceTree = "<group>"; };
 		CAC54C8427E38CE000CB3980 /* WeatherService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeatherService.swift; sourceTree = "<group>"; };
 		CAC54C8727E393A600CB3980 /* WeatherView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeatherView.swift; sourceTree = "<group>"; };
+		CAC54C8927E3AE3200CB3980 /* FollowedLocationsService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FollowedLocationsService.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -137,6 +139,7 @@
 			isa = PBXGroup;
 			children = (
 				CAC54C8427E38CE000CB3980 /* WeatherService.swift */,
+				CAC54C8927E3AE3200CB3980 /* FollowedLocationsService.swift */,
 			);
 			path = Services;
 			sourceTree = "<group>";
@@ -288,6 +291,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				CAC54C8A27E3AE3200CB3980 /* FollowedLocationsService.swift in Sources */,
 				CAC54C8827E393A600CB3980 /* WeatherView.swift in Sources */,
 				CAC54C8527E38CE000CB3980 /* WeatherService.swift in Sources */,
 				CAC54C5327E38A6700CB3980 /* WeatherViewController.swift in Sources */,

--- a/sample-app.xcodeproj/project.pbxproj
+++ b/sample-app.xcodeproj/project.pbxproj
@@ -19,6 +19,7 @@
 		CAC54C8527E38CE000CB3980 /* WeatherService.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAC54C8427E38CE000CB3980 /* WeatherService.swift */; };
 		CAC54C8827E393A600CB3980 /* WeatherView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAC54C8727E393A600CB3980 /* WeatherView.swift */; };
 		CAC54C8A27E3AE3200CB3980 /* FollowedLocationsService.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAC54C8927E3AE3200CB3980 /* FollowedLocationsService.swift */; };
+		CAC54C8C27E3C1FB00CB3980 /* sample-weather-response.json in Resources */ = {isa = PBXBuildFile; fileRef = CAC54C8B27E3C1FB00CB3980 /* sample-weather-response.json */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -55,6 +56,7 @@
 		CAC54C8427E38CE000CB3980 /* WeatherService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeatherService.swift; sourceTree = "<group>"; };
 		CAC54C8727E393A600CB3980 /* WeatherView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeatherView.swift; sourceTree = "<group>"; };
 		CAC54C8927E3AE3200CB3980 /* FollowedLocationsService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FollowedLocationsService.swift; sourceTree = "<group>"; };
+		CAC54C8B27E3C1FB00CB3980 /* sample-weather-response.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "sample-weather-response.json"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -114,6 +116,7 @@
 				CAC54C5727E38A6900CB3980 /* Assets.xcassets */,
 				CAC54C5927E38A6900CB3980 /* LaunchScreen.storyboard */,
 				CAC54C5C27E38A6900CB3980 /* Info.plist */,
+				CAC54C8B27E3C1FB00CB3980 /* sample-weather-response.json */,
 			);
 			path = "sample-app";
 			sourceTree = "<group>";
@@ -267,6 +270,7 @@
 				CAC54C5B27E38A6900CB3980 /* LaunchScreen.storyboard in Resources */,
 				CAC54C5827E38A6900CB3980 /* Assets.xcassets in Resources */,
 				CAC54C5627E38A6700CB3980 /* Main.storyboard in Resources */,
+				CAC54C8C27E3C1FB00CB3980 /* sample-weather-response.json in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/sample-app/Services/FollowedLocationsService.swift
+++ b/sample-app/Services/FollowedLocationsService.swift
@@ -7,7 +7,7 @@ import Foundation
 
 class FollowedLocationsService {
 
-    // Eventually this will talk to the backend and retrieve locations the user has added.
+    // Have this talk to the backend and retrieve locations the user has added.
     func fetchLocations(completion: @escaping ([Coordinates?]) -> Void) {
         completion([
             Coordinates(lat: 40.7128, lon: -74.0060),

--- a/sample-app/Services/FollowedLocationsService.swift
+++ b/sample-app/Services/FollowedLocationsService.swift
@@ -1,0 +1,19 @@
+//
+//  FollowedLocationsService.swift
+//  sample-app
+
+
+import Foundation
+
+class FollowedLocationsService {
+
+    // Eventually this will talk to the backend and retrieve locations the user has added.
+    func fetchLocations(completion: @escaping ([Coordinates?]) -> Void) {
+        completion([
+            Coordinates(lat: 40.7128, lon: -74.0060),
+            Coordinates(lat: 34.0522, lon: -118.2437),
+            Coordinates(lat: 42.4963, lon: -96.4049),
+            Coordinates(lat: 45.5152, lon: -122.6784)
+        ]);
+    }
+}

--- a/sample-app/Services/WeatherService.swift
+++ b/sample-app/Services/WeatherService.swift
@@ -12,7 +12,6 @@ class WeatherService {
 
     private let endpoint = "https://api.weatherapi.com/v1/current.json?key=2417772cc9494d49933164220202511&q=%f,%f"
 
-
     func fetchWeather(coordinates: Coordinates) async -> Weather? {
         guard
             let url = URL(string: String(format: endpoint, coordinates.lat, coordinates.lon)),
@@ -21,8 +20,12 @@ class WeatherService {
             return nil
         }
 
+        let formatter = DateFormatter()
+        formatter.dateFormat = "YYY-M-D HH:mm"
+        
         let decoder = JSONDecoder()
         decoder.keyDecodingStrategy = .convertFromSnakeCase
+        decoder.dateDecodingStrategy = .formatted(formatter)
 
         guard
             let dictionary = try? JSONSerialization.jsonObject(with: data, options : .allowFragments) as? [String: Any],
@@ -52,7 +55,7 @@ struct Weather: Codable {
 
 struct WeatherLocation: Codable {
     let name: String?
-    let localtimeEpoch: Date?
+    let localtime: Date?
     let region: String?
 }
 

--- a/sample-app/View Controllers/WeatherViewController.swift
+++ b/sample-app/View Controllers/WeatherViewController.swift
@@ -8,18 +8,31 @@ import UIKit
 
 class WeatherViewController: UIViewController {
 
+
+    private lazy var stackView: UIStackView = {
+        let view = UIStackView()
+        view.axis = .vertical
+        view.translatesAutoresizingMaskIntoConstraints = false
+        view.spacing = 10
+        view.distribution = .fillProportionally
+        return view
+    }()
+
     override func viewDidLoad() {
         super.viewDidLoad()
-
-        let weatherView = WeatherView(coordinates: Coordinates(lat: 40.71, lon: -74.01))
-        weatherView.translatesAutoresizingMaskIntoConstraints = false
-        view.addSubview(weatherView)
-
-        weatherView.topAnchor.constraint(equalTo: self.view.safeAreaLayoutGuide.topAnchor).isActive = true
-        weatherView.leadingAnchor.constraint(equalTo: self.view.safeAreaLayoutGuide.leadingAnchor).isActive = true
-        weatherView.trailingAnchor.constraint(equalTo: self.view.safeAreaLayoutGuide.trailingAnchor).isActive = true
+        view.addSubview(stackView)
+        stackView.topAnchor.constraint(equalTo: self.view.safeAreaLayoutGuide.topAnchor).isActive = true
+        stackView.leadingAnchor.constraint(equalTo: self.view.safeAreaLayoutGuide.leadingAnchor).isActive = true
+        stackView.trailingAnchor.constraint(equalTo: self.view.safeAreaLayoutGuide.trailingAnchor).isActive = true
+        stackView.bottomAnchor.constraint(equalTo: self.view.safeAreaLayoutGuide.bottomAnchor).isActive = true
+        let locationsService = FollowedLocationsService()
+        locationsService.fetchLocations { locations in
+            for coordinates in locations {
+                let weatherView = WeatherView(coordinates: coordinates!)
+                weatherView.translatesAutoresizingMaskIntoConstraints = false
+                self.stackView.addArrangedSubview(weatherView)
+            }
+        }
     }
-
-
 }
 

--- a/sample-app/View Controllers/WeatherViewController.swift
+++ b/sample-app/View Controllers/WeatherViewController.swift
@@ -8,6 +8,7 @@ import UIKit
 
 class WeatherViewController: UIViewController {
 
+    var locationsService: FollowedLocationsService?
 
     private lazy var stackView: UIStackView = {
         let view = UIStackView()
@@ -25,8 +26,8 @@ class WeatherViewController: UIViewController {
         stackView.leadingAnchor.constraint(equalTo: self.view.safeAreaLayoutGuide.leadingAnchor).isActive = true
         stackView.trailingAnchor.constraint(equalTo: self.view.safeAreaLayoutGuide.trailingAnchor).isActive = true
         stackView.bottomAnchor.constraint(equalTo: self.view.safeAreaLayoutGuide.bottomAnchor).isActive = true
-        let locationsService = FollowedLocationsService()
-        locationsService.fetchLocations { locations in
+        locationsService = FollowedLocationsService()
+        locationsService?.fetchLocations { locations in
             for coordinates in locations {
                 let weatherView = WeatherView(coordinates: coordinates!)
                 weatherView.translatesAutoresizingMaskIntoConstraints = false

--- a/sample-app/Views/WeatherView.swift
+++ b/sample-app/Views/WeatherView.swift
@@ -8,46 +8,35 @@
 import UIKit
 
 class WeatherView: UIView {
-    private var weather: Weather? {
-        didSet {
-            render()
-        }
-    }
+    private var weather: Weather?
 
     private lazy var mainStackView: UIStackView = {
-
         let view = UIStackView(arrangedSubviews: [locationLabel, conditionsStackView])
         view.translatesAutoresizingMaskIntoConstraints = false
         view.axis = .vertical
+        view.distribution = .fillProportionally
         return view
     }()
 
     private lazy var conditionsStackView: UIStackView = {
-        let view = UIStackView(arrangedSubviews: [conditionImage, tempFLabel, tempCLabel])
+        let view = UIStackView(arrangedSubviews: [conditionImage, tempFLabel, UIView()])
         view.translatesAutoresizingMaskIntoConstraints = false
         view.axis = .horizontal
         view.spacing = 10
-        view.alignment = .center
-        view.distribution = .equalCentering
+        view.distribution = .fillProportionally
         return view
     }()
 
     private let conditionImage: UIImageView = {
         let view = UIImageView()
-        view.widthAnchor.constraint(equalToConstant: 52).isActive = true
-        view.heightAnchor.constraint(equalToConstant: 52).isActive = true
+        view.widthAnchor.constraint(equalToConstant: 64).isActive = true
+        view.heightAnchor.constraint(equalToConstant: 64).isActive = true
         return view
     }()
 
     private let tempFLabel: UILabel = {
         let label = UILabel()
         label.font = .systemFont(ofSize: 32, weight: .bold)
-        return label
-    }()
-
-    private let tempCLabel: UILabel = {
-        let label = UILabel()
-        label.font = .systemFont(ofSize: 18, weight: .regular)
         return label
     }()
 
@@ -66,6 +55,7 @@ class WeatherView: UIView {
 
         Task {
             self.weather = await WeatherService.shared.fetchWeather(coordinates: coordinates)
+            render()
         }
     }
 
@@ -76,20 +66,19 @@ class WeatherView: UIView {
     private func render() {
         guard
             let tempF = weather?.forecast?.tempF,
-            let tempC = weather?.forecast?.tempC,
             let icon = weather?.forecast?.condition?.icon,
             let locationName = weather?.location?.name,
             let region = weather?.location?.region,
-            let condition = weather?.forecast?.condition?.text
+            let condition = weather?.forecast?.condition?.text,
+            let localTime = weather?.location?.localtime
         else {
             // TODO: error view
             return
         }
-
+        let formatter = DateFormatter()
+        formatter.dateFormat = "h:mm a"
         tempFLabel.text = "\(Int(tempF)) ℉"
-        tempCLabel.text = "\(tempC) ℃"
-        locationLabel.text = "\(condition) in \(locationName), \(region)"
-
+        locationLabel.text = "\(condition) in \(locationName), \(region) at \(formatter.string(from: localTime))"
         if let url = URL(string: "https:\(icon)"), let data = try? Data(contentsOf: url) {
             conditionImage.image = UIImage(data: data)
         }

--- a/sample-app/sample-weather-response.json
+++ b/sample-app/sample-weather-response.json
@@ -1,0 +1,41 @@
+{
+    "location": {
+        "name": "New York",
+        "region": "New York",
+        "country": "United States of America",
+        "lat": 40.71,
+        "lon": -74.01,
+        "tz_id": "America/New_York",
+        "localtime_epoch": 1647543659,
+        "localtime": "2022-03-17 15:00"
+    },
+    "current": {
+        "last_updated_epoch": 1647542700,
+        "last_updated": "2022-03-17 14:45",
+        "temp_c": 10.6,
+        "temp_f": 51.1,
+        "is_day": 1,
+        "condition": {
+        "text": "Fog",
+        "icon": "//cdn.weatherapi.com/weather/64x64/day/248.png",
+        "code": 1135
+    },
+    "wind_mph": 12.5,
+    "wind_kph": 20.2,
+    "wind_degree": 50,
+    "wind_dir": "NE",
+    "pressure_mb": 1015,
+    "pressure_in": 29.96,
+    "precip_mm": 0.9,
+    "precip_in": 0.04,
+    "humidity": 86,
+    "cloud": 100,
+    "feelslike_c": 9.5,
+    "feelslike_f": 49,
+    "vis_km": 0.2,
+    "vis_miles": 0,
+    "uv": 2,
+    "gust_mph": 8.5,
+    "gust_kph": 13.7
+    }
+}


### PR DESCRIPTION
## Description of Changes, Motivation and Context
- Updates `WeatherViewController` to display multiple `WeatherView` views.
- Adds `FollowedLocationsService` which will return coordinates for the user's followed locations.
- Adds `localTime` property to `WeatherLocation` and includes it on `WeatherView` per our discussion at standup.
- Increases the size of the condition image to 64 per design feedback.
- Removes celsius temperature label since the PM said no one cares about it.

I also added `sample-weather-response.json` as a reference.

## Types of changes
<!--- Put an `x` in all the boxes that apply: -->
- [ ] Bug fix
- [x] New feature
- [ ] Feature enhancement
- [ ] Code cleanup / refactor / tech debt

## Checklist
<!--- Put an `x` in all the boxes that apply. -->
- [x] I have added an entry to **CHANGELOG.md** (if other than Code Cleanup).
- [ ] I have updated the documentation accordingly.
- [ ] I have included instrumentation if this is a new feature. 
- [ ] I have run the Accessibility Inspector if this is a new feature.
- [ ] My changes are covered by unit tests, _or I assert that unit tests do not apply_.

## Screenshot
![Simulator Screen Shot - iPhone 12 - 2022-03-17 at 15 15 17](https://user-images.githubusercontent.com/423991/159025748-91d522f1-c178-4254-96db-c02faaa856bc.png)

